### PR TITLE
Fix authentication secret fallback in middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -10,7 +10,8 @@ const isProtectedRoute = (pathname: string) =>
 
 export async function middleware(request: NextRequest) {
   const { pathname, search } = request.nextUrl;
-  const token = await getToken({ req: request, secret: process.env.AUTH_SECRET });
+  const secret = process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET;
+  const token = await getToken({ req: request, secret });
   const isAuthenticated = Boolean(token);
 
   if (isAuthenticated && isAuthRoute(pathname)) {


### PR DESCRIPTION
## Summary
- update middleware to fall back to NEXTAUTH_SECRET when AUTH_SECRET is not set
- ensure protected routes remain accessible after deployment

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e63714b7208330b5e248a8a509de1f